### PR TITLE
Add OSGi Metadata

### DIFF
--- a/bnd/jakarta.inject-api.bnd
+++ b/bnd/jakarta.inject-api.bnd
@@ -1,0 +1,4 @@
+-removeheaders: Private-Package
+
+-exportcontents: \
+    javax.inject

--- a/delegate.bnd
+++ b/delegate.bnd
@@ -1,0 +1,6 @@
+Bundle-Developers:
+Bundle-DocURL:
+Bundle-License:
+Bundle-SCM:
+
+-include: ${project.rootdir}/bnd/${project.artifactId}.bnd


### PR DESCRIPTION
Add OSGi rules and predefined metadata in the form of bnd-files handled by the bnd-maven plugin.